### PR TITLE
0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ To better understand the changelog, here are some legends we use:
 
 `2022-03-17`
 
-- 🐛 Fix email check on `Input` [#12](https://github.com/cap-collectif/form/pull/15)
+- 🐛 Fix email check on `Input` [#15](https://github.com/cap-collectif/form/pull/15)
 
 ## 0.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 0.1.6
+
+`2022-03-17`
+
+- 🐛 Fix email check on `Input` [#12](https://github.com/cap-collectif/form/pull/15)
+
 ## 0.1.5
 
 `2022-02-22`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "name": "@cap-collectif/form",
   "author": "Cap Collectif <tech@cap-collectif.com>",


### PR DESCRIPTION
`2022-03-17`

- 🐛 Fix email check on `Input` [#15](https://github.com/cap-collectif/form/pull/15)