### PR TITLE
Handle case error for nested fields

### DIFF
--- a/src/components/Form.stories.tsx
+++ b/src/components/Form.stories.tsx
@@ -206,28 +206,29 @@ export const Default = () => {
         <FormLabel label="Choisissez une couleur :" />
         <FormGuideline>Tell us about you</FormGuideline>
         <FormControl
-          name="CountryCode"
+          name="phone.countryCode"
           control={control}
           isRequired
           style={{ flex: '50%' }}
         >
           <FieldInput
             type="flagSelect"
-            name="CountryCode"
+            name="phone.countryCode"
             control={control}
             placeholder="Choisir un pays"
           />
         </FormControl>
         <FormControl
-          name="phoneNumber"
+          name="phone.phoneNumber"
           control={control}
           isRequired
           style={{ flex: '50%' }}
         >
           <FieldInput
             type="tel"
-            name="phoneNumber"
+            name="phone.phoneNumber"
             maxLength={10}
+            minLength={2}
             control={control}
           />
         </FormControl>

--- a/src/components/FormControl.tsx
+++ b/src/components/FormControl.tsx
@@ -2,7 +2,7 @@
 
 import type { FC } from 'react';
 import { useIntl } from 'react-intl';
-import { Control, useController } from 'react-hook-form';
+import { Control, useController, FormState } from 'react-hook-form';
 import {
     CapInputSize,
     FormControl as CapFormControl,
@@ -13,6 +13,16 @@ import {
 export interface FormControlProps extends CapFormControlProps {
     name: string;
     control: Control<any>;
+}
+
+const getTouchedState = (touchedFields: FormState['touchedFields'], name: string): boolean => {
+    const isNestedField = name.includes('.');
+    if(!isNestedField) return touchedFields[name]
+
+    const [firstPart, secondPart] = name.split('.');
+    if(touchedFields[firstPart]) return touchedFields[firstPart][secondPart]
+
+    return false;
 }
 
 export const FormControl: FC<FormControlProps> = ({
@@ -35,8 +45,7 @@ export const FormControl: FC<FormControlProps> = ({
             required: isRequired ? intl.formatMessage({ id: 'fill-field' }) : undefined,
         },
     });
-
-    const isInvalid = invalid && touchedFields[name];
+    const isInvalid = invalid && getTouchedState(touchedFields, name);
 
     return (
         <CapFormControl


### PR DESCRIPTION
#### :tophat: What? Why?
- [x] On gère les erreurs pour les champs seraient imbriqués (ex: `phone.phoneNumber`)