### PR TITLE
added real address to address field with hidden input

### DIFF
--- a/src/components/address/Address.tsx
+++ b/src/components/address/Address.tsx
@@ -9,23 +9,25 @@ import PlacesAutocomplete, {
 
 import type { AddressComplete, AddressWithoutPosition } from './Address.type'
 
-export type AddressProps = InputProps
+export type AddressProps = InputProps & {
+  getAddress?: (address: AddressComplete) => void
+}
 const Address: React.FC<AddressProps> = ({
   value,
   onChange,
   placeholder,
   className,
   width,
+  getAddress,
 }) => {
   const handleSelect = async (address: string) => {
-    const addressWithoutPosition: AddressWithoutPosition = await geocodeByAddress(
-      address,
-    )
-      .then((results: AddressWithoutPosition[]) => {
-        // There is no lat & lng here
-        return results[0]
-      })
-      .catch(error => console.error('Error', error))
+    const addressWithoutPosition: AddressWithoutPosition =
+      await geocodeByAddress(address)
+        .then((results: AddressWithoutPosition[]) => {
+          // There is no lat & lng here
+          return results[0]
+        })
+        .catch(error => console.error('Error', error))
 
     await getLatLng(addressWithoutPosition)
       .then(latLng => {
@@ -39,11 +41,11 @@ const Address: React.FC<AddressProps> = ({
             },
           },
         }
+        if (getAddress) getAddress(addressComplete)
         onChange(addressComplete.formatted_address)
       })
       .catch(error => console.error('Error', error))
   }
-
   return (
     <PlacesAutocomplete
       value={value}

--- a/src/components/fieldInput/FieldInput.tsx
+++ b/src/components/fieldInput/FieldInput.tsx
@@ -70,6 +70,7 @@ export const FieldInput: FC<FieldInputProps> = ({
 
   switch (type) {
     default:
+    case 'hidden':
     case 'text':
     case 'email':
     case 'password':

--- a/src/components/fieldInput/FieldInput.type.ts
+++ b/src/components/fieldInput/FieldInput.type.ts
@@ -72,7 +72,7 @@ export type FieldTextArea = {
 } & TextAreaProps
 
 export type FieldText = {
-  type: 'text' | 'email' | 'password' | 'tel'
+  type: 'text' | 'email' | 'password' | 'tel' | 'hidden'
 } & InputProps
 
 export type FieldSwitch = {


### PR DESCRIPTION
Hello there, 
This PR is to change the `Address` Component so we can retrieve the address object sent by the GoogleAPI.
We use A hidden FieldInput to store the address object so we can have it in the onSubmit method.
I didn't add an example to the storybook since it need the GOOGLE_API_KEY
### Example
```jsx
<FormControl name="city" control={control} isRequired>
	<FormLabel label="City" />
	  <FieldInput
	      type="address"
	  name="city"
	  control={control}
	  defaultValue=""
	  placeholder="Address"
	  getAddress={add => {
	      setValue('realAddress', add)
	  }}
	  />
</FormControl>
<FormControl
style={{ display: 'none' }}
name="realAddress"
control={control}
isRequired
>
	  <FieldInput
	      type="hidden"
	  name="realAddress"
	  control={control}
	  defaultValue=""
	  placeholder="Address"
	      />
    </FormControl>
```


Thanks