### PR TITLE
v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 0.3.2
+
+`2022-05-19`
+
+- 🐛 Added `getAddress` callback to `Address` component to get full address [#33](https://github.com/cap-collectif/form/pull/33)
+
 ## 0.3.1
 
 `2022-05-11`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ To better understand the changelog, here are some legends we use:
 `2022-05-19`
 
 - 🐛 Added `getAddress` callback to `Address` component to get full address [#33](https://github.com/cap-collectif/form/pull/33)
+- 🐛 Added `hidden` type to input [#33](https://github.com/cap-collectif/form/pull/33)
 
 ## 0.3.1
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "name": "@cap-collectif/form",
   "author": "Cap Collectif <tech@cap-collectif.com>",


### PR DESCRIPTION
## 0.3.2

`2022-05-19`

- 🐛 Added `getAddress` callback to `Address` component to get full address [#33](https://github.com/cap-collectif/form/pull/33)
