### PR TITLE
fix AsyncSelect onChange for single value

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -56,7 +56,7 @@ export const Select: React.FC<SelectProps> = ({
                 }
                 onChange={newValue => {
                     if (typeof onChange === 'function') {
-                        onChange(rest.isMulti ? newValue : newValue?.value || '');
+                        onChange(newValue)
                     }
                 }}
             />


### PR DESCRIPTION
Dans le cas où on utilise la prop `loadOptions` sur le compo `Select` avec `isMulti` à `false` il faut retourner la valeur sous le format `{ value: '', label: '' }`, actuellement il retourne juste la `value`