### PR TITLE
0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+# 0.5.1
+
+`2023-03-14`
+
+- 🛠 Bump `@cap-collectif/ui` version to latest [#46](https://github.com/cap-collectif/form/pull/46)
+
 # 0.5.0
 
 `2023-01-24`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "name": "@cap-collectif/form",
   "author": "Cap Collectif <tech@cap-collectif.com>",


### PR DESCRIPTION
# 0.5.1

`2023-03-14`

- 🛠 Bump `@cap-collectif/ui` version to latest [#46](https://github.com/cap-collectif/form/pull/46)