### PR TITLE
forward DateInput props in DateHour input

### DIFF
--- a/src/components/Form.stories.tsx
+++ b/src/components/Form.stories.tsx
@@ -253,7 +253,9 @@ export const Default = () => {
 
       <FormControl name="dateHour" control={control} isRequired>
         <FormLabel label="Date With Hour" />
-        <FieldInput type="dateHour" name="dateHour" control={control} />
+        <FieldInput type="dateHour" name="dateHour" control={control} dateInputProps={{
+          isOutsideRange: true
+        }} />
       </FormControl>
 
       <FormControl name="color" control={control} isRequired>

--- a/src/components/dateHour/DateHour.tsx
+++ b/src/components/dateHour/DateHour.tsx
@@ -7,6 +7,7 @@ import {
   DateInputValueType,
   Box,
   useTheme,
+  DateInputProps,
 } from '@cap-collectif/ui'
 import moment from 'moment'
 import { FC, useEffect, useState } from 'react'
@@ -15,6 +16,7 @@ export interface DateHourProps extends Omit<BoxPropsOf<'input'>, 'onChange'> {
   readonly isDisabled?: boolean
   readonly isInvalid?: boolean
   readonly variantSize?: CapInputSize
+  readonly dateInputProps?: Partial<DateInputProps>
 }
 
 const DATE_FORMAT = 'YYYY-MM-DD H:mm:ss'
@@ -25,6 +27,7 @@ export const DateHour: FC<DateHourProps> = ({
   variantSize = CapInputSize.Sm,
   isDisabled,
   isInvalid,
+  dateInputProps = {}
 }) => {
   const { colors } = useTheme()
   const initialDate = value ? moment(value, DATE_FORMAT) : null
@@ -70,6 +73,7 @@ export const DateHour: FC<DateHourProps> = ({
           variantSize={variantSize}
           isDisabled={isDisabled}
           isInvalid={isInvalid}
+          {...dateInputProps}
         />
         <HourInput
           onChange={(newHourValue: string) => {


### PR DESCRIPTION
On permet le passage des props du compo DateInput vers le compo DateHour
FieldInput > DateHour > DateInput

**usage example :** 
`<FieldInput type="dateHour" name="dateHour" control={control} dateInputProps={{
          isOutsideRange: true
        }} />`