### PR TITLE
parse int value if input is of type number

### DIFF
--- a/src/components/fieldInput/FieldInput.tsx
+++ b/src/components/fieldInput/FieldInput.tsx
@@ -74,9 +74,14 @@ export const FieldInput: FC<FieldInputProps> = forwardRef(
     })
 
     const handleOnChange = (e): void => {
-      if (onChange) onChange(e)
+      if (onChange) {
+        onChange(e)
+        return;
+      }
       if (type === 'number') {
-        field.onChange(parseInt(e.target.value))
+        const newEvent = { ...e, target: { ...e.target, value: parseInt(e.target.value) } }
+        field.onChange(newEvent)
+        return;
       }
       field.onChange(e)
     }

--- a/src/components/fieldInput/FieldInput.tsx
+++ b/src/components/fieldInput/FieldInput.tsx
@@ -74,10 +74,7 @@ export const FieldInput: FC<FieldInputProps> = forwardRef(
     })
 
     const handleOnChange = (e): void => {
-      if (onChange) {
-        onChange(e)
-        return;
-      }
+      if (onChange) onChange(e)
       if (type === 'number') {
         const newEvent = { ...e, target: { ...e.target, value: parseInt(e.target.value) } }
         field.onChange(newEvent)

--- a/src/components/fieldInput/FieldInput.tsx
+++ b/src/components/fieldInput/FieldInput.tsx
@@ -76,7 +76,7 @@ export const FieldInput: FC<FieldInputProps> = forwardRef(
     const handleOnChange = (e): void => {
       if (onChange) onChange(e)
       if (type === 'number') {
-        const newEvent = { ...e, target: { ...e.target, value: parseInt(e.target.value) } }
+        const newEvent = { ...e, target: { ...e.target, value: Number(e.target.value) } }
         field.onChange(newEvent)
         return;
       }

--- a/src/components/fieldInput/FieldInput.tsx
+++ b/src/components/fieldInput/FieldInput.tsx
@@ -75,6 +75,9 @@ export const FieldInput: FC<FieldInputProps> = forwardRef(
 
     const handleOnChange = (e): void => {
       if (onChange) onChange(e)
+      if (type === 'number') {
+        field.onChange(parseInt(e.target.value))
+      }
       field.onChange(e)
     }
 


### PR DESCRIPTION
On souhaite avoir directement la valeur en `int` lorsque l'on reçoit la valeur d'un input type number

dans la doc de RHF il existe une props `valueAsNumber` dans l'api `register`
https://react-hook-form.com/docs/useform/register

sauf que dans notre cas on passe par les `Controller` et d'après cette [issue](https://github.com/orgs/react-hook-form/discussions/8068#discussioncomment-2415789) `valueAsNumber` n'est pas dispo dans `Controller`

la solution simple est donc de parser la valeur au onChange