### PR TITLE
0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+# 0.6.0
+
+`2024-04-19`
+
+- 💥 Use native date input [#79](https://github.com/cap-collectif/form/pull/79)
+- 🛠 Separate onChange logic for specific inputs [#79](https://github.com/cap-collectif/form/pull/79)
+
 # 0.5.9
 
 `2024-02-23`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.9",
+  "version": "0.6.0",
   "license": "MIT",
   "name": "@cap-collectif/form",
   "author": "Cap Collectif <tech@cap-collectif.com>",


### PR DESCRIPTION
# 0.6.0

`2024-04-19`

- 💥 Use native date input [#79](https://github.com/cap-collectif/form/pull/79)
- 🛠 Separate onChange logic for specific inputs [#79](https://github.com/cap-collectif/form/pull/79)