### PR TITLE
handle nullable value in dateHour component

### DIFF
--- a/src/components/dateHour/DateHour.tsx
+++ b/src/components/dateHour/DateHour.tsx
@@ -38,6 +38,7 @@ export const DateHour: FC<DateHourProps> = ({
 
   useEffect(() => {
     if (!dateValue) {
+      onChange()
       return
     }
 
@@ -71,7 +72,8 @@ export const DateHour: FC<DateHourProps> = ({
       <InputGroup sx={{ flexWrap: 'nowrap !important' }}>
         <DateInput
           onChange={(newDateValue: React.ChangeEvent<HTMLInputElement>) => {
-            setDateValue(moment(newDateValue.target.value, DATE_FORMAT))
+            const value = newDateValue.target.value ? moment(newDateValue.target.value, DATE_FORMAT) : null
+            setDateValue(value)
           }}
           value={dateValue?.format('YYYY-MM-DD')}
           variantSize={variantSize}


### PR DESCRIPTION
issue : 
- #84 

quand on formate `null` via moment ça renvoie `Invalid date`, je fais en sorte de ne pas le formater si pas de valeur
il faut aussi call `onChange` dans le early return sinon il met pas à jour la valeur