### PR TITLE
fix: add missing id prop to BaseField type

### DIFF
--- a/src/components/fieldInput/FieldInput.type.ts
+++ b/src/components/fieldInput/FieldInput.type.ts
@@ -40,7 +40,7 @@ export type BaseField = {
   onChange?: (event: SyntheticEvent) => void
   defaultValue?: any
   rules?: Rules
-  id: string
+  id?: string
 }
 
 export type AllFieldTypes =

--- a/src/components/fieldInput/FieldInput.type.ts
+++ b/src/components/fieldInput/FieldInput.type.ts
@@ -40,6 +40,7 @@ export type BaseField = {
   onChange?: (event: SyntheticEvent) => void
   defaultValue?: any
   rules?: Rules
+  id: string
 }
 
 export type AllFieldTypes =


### PR DESCRIPTION
On a une erreur ts sur les FieldInput car il manque la prop `id` dans le typage.
Une fois mergé, on pourra retirer les 2 "// @ts-ignore cap-collectif/form/issues/53" qui restent (je me le note)