### PR TITLE
0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+# 0.6.4
+
+`2024-07-04`
+
+- 🐛 Add an optional `id` prop on FieldInput component [#89](https://github.com/cap-collectif/form/pull/89)
+
 # 0.6.3
 
 `2024-05-14`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "name": "@cap-collectif/form",
   "author": "Cap Collectif <tech@cap-collectif.com>",


### PR DESCRIPTION
# 0.6.4

`2024-07-04`

- 🐛 Add an optional `id` prop on FieldInput component [#89](https://github.com/cap-collectif/form/pull/89)
