### PR TITLE
fix: improve form accessibility

### DIFF
--- a/src/components/FormControl.tsx
+++ b/src/components/FormControl.tsx
@@ -1,82 +1,98 @@
 // @ts-nocheck
 
-import type { FC } from 'react';
-import React from 'react';
-import { useIntl } from 'react-intl';
-import { Control, useController, FormState } from 'react-hook-form';
+import type { FC } from 'react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+import { Control, useController, FormState } from 'react-hook-form'
 import {
-    CapInputSize,
-    FormControl as CapFormControl,
-    FormControlProps as CapFormControlProps,
-    FormErrorMessage,
-} from '@cap-collectif/ui';
+  CapInputSize,
+  FormControl as CapFormControl,
+  FormControlProps as CapFormControlProps,
+  FormErrorMessage,
+} from '@cap-collectif/ui'
 
 export interface FormControlProps extends CapFormControlProps {
-    name: string;
-    control: Control<any>;
+  name: string
+  control: Control<any>
 }
 
-const getTouchedState = (touchedFields: FormState['touchedFields'], name: string): boolean => {
-    const isNestedField = name.includes('.');
-    if(!isNestedField) return touchedFields[name]
+const getTouchedState = (
+  touchedFields: FormState['touchedFields'],
+  name: string,
+): boolean => {
+  const isNestedField = name.includes('.')
+  if (!isNestedField) return touchedFields[name]
 
-    const [firstPart, secondPart] = name.split('.');
-    if(touchedFields[firstPart]) return touchedFields[firstPart][secondPart]
+  const [firstPart, secondPart] = name.split('.')
+  if (touchedFields[firstPart]) return touchedFields[firstPart][secondPart]
 
-    return false;
+  return false
 }
 
 export const FormControl: FC<FormControlProps> = ({
+  name,
+  control,
+  children,
+  variantSize = CapInputSize.Sm,
+  sx,
+  isRequired,
+  ...props
+}) => {
+  const intl = useIntl()
+  const {
+    field,
+    fieldState: { invalid, error },
+    formState: { touchedFields },
+  } = useController({
     name,
     control,
-    children,
-    variantSize = CapInputSize.Sm,
-    sx,
-    isRequired,
-    ...props
-}) => {
-    const intl = useIntl();
-    const {
-        field,
-        fieldState: { invalid, error },
-        formState: { touchedFields },
-    } = useController({
-        name,
-        control,
-        rules: {
-            required: isRequired ? intl.formatMessage({ id: 'fill-field' }) : undefined,
+    rules: {
+      required: isRequired
+        ? intl.formatMessage({ id: 'fill-field' })
+        : undefined,
+    },
+  })
+  const isInvalid = invalid && getTouchedState(touchedFields, name)
+
+  const errorFieldId = `${name}-error`
+
+  const childrenWithProps = React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      if (child?.type?.displayName === 'FieldInput') {
+        return React.cloneElement(child, {
+          ref: field.ref,
+          'aria-describedby': isInvalid ? errorFieldId : undefined,
+        })
+      }
+      return React.cloneElement(child)
+    }
+    return null
+  })
+
+  return (
+    <CapFormControl
+      variantSize={variantSize}
+      mb={4}
+      isInvalid={isInvalid}
+      isRequired={isRequired}
+      toto="toto"
+      sx={{
+        '&:last-child': {
+          mb: 0,
         },
-    });
-    const isInvalid = invalid && getTouchedState(touchedFields, name);
+        ...sx,
+      }}
+      {...props}
+    >
+      {childrenWithProps}
 
-    const childrenWithProps = React.Children.map(children, child => {
-        if (React.isValidElement(child)) {
-            if (child?.type?.displayName === 'FieldInput') {
-                return React.cloneElement(child, { ref: field.ref });
-            }
-            return React.cloneElement(child);
-        }
-        return null;
-    });
+      {isInvalid && error?.message && (
+        <FormErrorMessage color="red.600" id={errorFieldId}>
+          {error.message}
+        </FormErrorMessage>
+      )}
+    </CapFormControl>
+  )
+}
 
-    return (
-        <CapFormControl
-            variantSize={variantSize}
-            mb={4}
-            isInvalid={isInvalid}
-            isRequired={isRequired}
-            sx={{
-                '&:last-child': {
-                    mb: 0,
-                },
-                ...sx,
-            }}
-            {...props}>
-            {childrenWithProps}
-
-            {isInvalid && error?.message && <FormErrorMessage>{error.message}</FormErrorMessage>}
-        </CapFormControl>
-    );
-};
-
-export default FormControl;
+export default FormControl


### PR DESCRIPTION
- Contraste amélioré sur le message d'erreur
- Ajout d'un id au message d'erreur. Si l'input est invalide, on lui ajoute `aria-described-by` avec l'id du message d'erreur lié.

Sorry pour le formattage, le fichier n'avait pas de prettier. Faut regarder juste la variable `errorFieldId` qui est passée au besoin 👌 