### PR TITLE
fix: refactor hour input

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.12",
-    "@cap-collectif/ui": "^1.10.5",
+    "@cap-collectif/ui": "^1.10.13",
     "@size-limit/preset-small-lib": "^7.0.5",
     "@size-limit/webpack": "^7.0.5",
     "@size-limit/webpack-why": "^7.0.5",

--- a/src/components/dateHour/DateHour.tsx
+++ b/src/components/dateHour/DateHour.tsx
@@ -42,7 +42,7 @@ export const DateHour: FC<DateHourProps> = ({
       return
     }
 
-    const formattedHour = moment(hourValue ?? '00:00', 'hh:mm')
+    const formattedHour = moment(hourValue ?? '00:00', 'HH:mm')
     const dateHour = moment(dateValue ?? moment.now())
       .set({
         hour: formattedHour.get('hour'),
@@ -72,7 +72,9 @@ export const DateHour: FC<DateHourProps> = ({
       <InputGroup sx={{ flexWrap: 'nowrap !important' }}>
         <DateInput
           onChange={(newDateValue: React.ChangeEvent<HTMLInputElement>) => {
-            const value = newDateValue.target.value ? moment(newDateValue.target.value, DATE_FORMAT) : null
+            const value = newDateValue.target.value
+              ? moment(newDateValue.target.value, DATE_FORMAT)
+              : null
             setDateValue(value)
           }}
           value={dateValue?.format('YYYY-MM-DD')}
@@ -85,7 +87,6 @@ export const DateHour: FC<DateHourProps> = ({
           onChange={(newHourValue: string) => {
             setHourValue(newHourValue)
           }}
-          value={hourValue}
           variantSize={variantSize}
           isDisabled={isDisabled}
           isInvalid={isInvalid}

--- a/src/components/dateHour/DateHour.tsx
+++ b/src/components/dateHour/DateHour.tsx
@@ -41,8 +41,7 @@ export const DateHour: FC<DateHourProps> = ({
       onChange(null)
       return
     }
-
-    const formattedHour = moment(hourValue ?? '00:00', 'HH:mm')
+    const formattedHour = moment(hourValue ?? '00:00', 'hh:mm')
     const dateHour = moment(dateValue ?? moment.now())
       .set({
         hour: formattedHour.get('hour'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,10 +1172,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cap-collectif/ui@^1.10.5":
-  version "1.10.12"
-  resolved "https://registry.yarnpkg.com/@cap-collectif/ui/-/ui-1.10.12.tgz#10c8e5cf0d904360ca42f013763122fa079f20ef"
-  integrity sha512-2gDSH1drI1q4gjQLFlOvp6N/soKMOcizrvvYiPY5ypEJQEu1ql7JbOG/PUR6heYN5VJUqJrTd/N55rpImF1cig==
+"@cap-collectif/ui@^1.10.13":
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/@cap-collectif/ui/-/ui-1.10.13.tgz#47446551ddfb7ff1b53a23eb38bca11ab294052d"
+  integrity sha512-1ojzpo0SbQWexNE3Kq+PF5GuXJxROhgM6MBmlHqS88x31iOPy5OqEj7dn5+BjoWBygH3CmhAz2+zTpHNySq5zA==
   dependencies:
     "@styled-system/css" "^5.1.5"
     "@styled-system/should-forward-prop" "^5.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,9 +1173,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cap-collectif/ui@^1.10.5":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/@cap-collectif/ui/-/ui-1.10.5.tgz#cbd5ff1431c8709ce8c0dddc52bf75e431f0ce69"
-  integrity sha512-rTYzMPLUGjdaBa73+zGwdpXwYZCKms1w/4HNdmtQFz+WHHHsQo5O1j9s57btTZdg4ASjemWu0ReF/SS19kG2SA==
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/@cap-collectif/ui/-/ui-1.10.12.tgz#10c8e5cf0d904360ca42f013763122fa079f20ef"
+  integrity sha512-2gDSH1drI1q4gjQLFlOvp6N/soKMOcizrvvYiPY5ypEJQEu1ql7JbOG/PUR6heYN5VJUqJrTd/N55rpImF1cig==
   dependencies:
     "@styled-system/css" "^5.1.5"
     "@styled-system/should-forward-prop" "^5.1.5"


### PR DESCRIPTION
On a modifié l'input de type heure dans capco/ui -> mise à jour du composant pour qu'il fonctionne correctement après les changements.

Note : storybook ne compilant plus suite à la montée de version de node, ce ticket ajoute une variable d'environnement dans le `package.json` pour permettre de compiler, mais cela devra sûrement être corrigé de façon plus pérenne.